### PR TITLE
Add "extId" child for OrderHeader

### DIFF
--- a/src/Pohoda/Order/Header.php
+++ b/src/Pohoda/Order/Header.php
@@ -12,6 +12,7 @@ namespace Riesenia\Pohoda\Order;
 
 use Riesenia\Pohoda\Common\OptionsResolver;
 use Riesenia\Pohoda\Document\Header as DocumentHeader;
+use Riesenia\Pohoda\Type\ExtId;
 
 class Header extends DocumentHeader
 {
@@ -19,7 +20,16 @@ class Header extends DocumentHeader
     protected $_refElements = ['number', 'paymentType', 'priceLevel', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'carrier'];
 
     /** @var string[] */
-    protected $_elements = ['orderType', 'number', 'numberOrder', 'date', 'dateDelivery', 'dateFrom', 'dateTo', 'text', 'partnerIdentity', 'myIdentity', 'paymentType', 'priceLevel', 'isExecuted', 'isReserved', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'carrier', 'intNote', 'markRecord'];
+    protected $_elements = ['extId', 'orderType', 'number', 'numberOrder', 'date', 'dateDelivery', 'dateFrom', 'dateTo', 'text', 'partnerIdentity', 'myIdentity', 'paymentType', 'priceLevel', 'isExecuted', 'isReserved', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'carrier', 'intNote', 'markRecord'];
+
+    public function __construct(array $data, string $ico, bool $resolveOptions = true)
+    {
+        if (isset($data['extId'])) {
+            $data['extId'] = new ExtId($data['extId'], $ico, $resolveOptions);
+        }
+
+        parent::__construct($data, $ico, $resolveOptions);
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Pohoda/Type/ExtId.php
+++ b/src/Pohoda/Type/ExtId.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Riesenia\Pohoda\Type;
+
+use Riesenia\Pohoda\Agenda;
+use Riesenia\Pohoda\Common\OptionsResolver;
+
+class ExtId extends Agenda
+{
+    /** @var string[] */
+    protected $_elements = ['ids', 'exSystemName', 'exSystemText'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getXML(): \SimpleXMLElement
+    {
+        $xml = $this->_createXML()->addChild('ord:extId', '', $this->_namespace('ord'));
+
+        $this->_addElements($xml, $this->_elements, 'typ');
+
+        return $xml;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _configureOptions(OptionsResolver $resolver)
+    {
+        // available options
+        $resolver->setDefined($this->_elements);
+
+        $resolver->setNormalizer('ids', $resolver->getNormalizer('string64'));
+        $resolver->setNormalizer('exSystemName', $resolver->getNormalizer('string64'));
+        $resolver->setNormalizer('exSystemText', $resolver->getNormalizer('string'));
+    }
+}


### PR DESCRIPTION
I would like to add the `extId` child for orderHeader. Attempted some implementation that I tested locally and that works.

Not sure if my attempt is the "proper" way of doing it.

Adding some documentation for reference.

https://www.stormware.cz/schema/version_2/order.xsd

```xml
<xsd:element name="extId" type="typ:extIdType" minOccurs="0">
<xsd:annotation>
<xsd:documentation> Odkaz na záznam v externí databázi. V databázi se nachází speciální tabulka obsahující vazbu mezi agendou a externí databází. </xsd:documentation>
</xsd:annotation>
</xsd:element>
```

https://www.stormware.cz/schema/version_2/type.xsd

```xml
<xsd:complexType name="extIdType">
<xsd:all>
<xsd:element name="ids" type="typ:string64">
<xsd:annotation>
<xsd:documentation>ID záznamu v externím systému, jedinečný textový identifikátor.</xsd:documentation>
</xsd:annotation>
</xsd:element>
<xsd:element name="exSystemName" type="typ:string64">
<xsd:annotation>
<xsd:documentation>Jedinečný název externího systému (např. GUID).</xsd:documentation>
</xsd:annotation>
</xsd:element>
<xsd:element name="exSystemText" type="xsd:string" minOccurs="0">
<xsd:annotation>
<xsd:documentation>Textový popis externího systému.</xsd:documentation>
</xsd:annotation>
</xsd:element>
</xsd:all>
</xsd:complexType>
```